### PR TITLE
Support creating build environment using Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ deploy/am335x-pocketbeagle.dtb
 deploy/zImage
 deploy/lib/
 deploy/modules.tar.gz
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-16.04"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.cpus = "4"
+
+    vb.memory = "2048"
+ 
+    # support symlinks in /vagrant (on Windows this required starting vagrant in an Admin shell)
+    vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install -y libncurses5-dev bc
+
+    # Do a clean checkout and build inside VM.
+    # Cannot use shared folder because Windows don't support symlinks (without admin rights) and mmap (mkimage fails).
+    cd /home/vagrant
+    sudo -u vagrant git clone https://github.com/lucasrangit/Supercon-2017-PocketBeagle.git 
+    cd Supercon-2017-PocketBeagle
+    sudo -u vagrant ./scripts/get_all.sh
+  SHELL
+end

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,25 @@
+# Supercon 2017 PocketBeagle Workshop
+
+## Hardware
+
 Part List: http://www.digikey.com/short/qt08d7
+
+## Setup
+
+The development environment is contained inside a Linux virtual machine. The contents of the current directory are shared/mounted inside the VM at `/vagrant`.
+
+1. Install [VirtualBox 5.1.x](https://www.virtualbox.org/wiki/Download_Old_Builds_5_1) (don't use 5.2.x)
+   - You can also use libvirt or VMware (with a paid plug-in)
+1. Install [Vagrant](https://www.vagrantup.com/downloads.html) >= 2.0.1
+1. Open Terminal
+   - Windows: Open a command prompt as Administrator (in order for symlinks in /vagrant to work)
+1. Run `vagrant up`
+
+## Build
+
+1. `vagrant ssh -c "cd Supercon-2017-PocketBeagle; ./scripts/build_u-boot.sh"`
+1. `vagrant ssh -c "cd Supercon-2017-PocketBeagle; ./scripts/build_linux.sh"`
+
+## Usage
+
+1. `vagrant ssh`

--- a/scripts/get_all.sh
+++ b/scripts/get_all.sh
@@ -8,9 +8,7 @@ dl_web () {
 }
 
 dl_local () {
-	if [ ! -f ./${pre}/${file} ] ; then
-		wget --progress=bar:force --timeout=2 --tries=2 -c --directory-prefix=./${pre}/ ${local_mirror}${pre}/${file} || dl_web
-	fi
+	wget --progress=bar:force --timeout=2 --tries=2 -c --directory-prefix=./${pre}/ ${local_mirror}${pre}/${file} || dl_web
 }
 
 if [ ! -d ./toolchain ] ; then

--- a/scripts/get_all.sh
+++ b/scripts/get_all.sh
@@ -1,15 +1,15 @@
 #!/bin/bash -e
-
+set -x
 local_mirror="http://192.168.8.10/"
 web_mirror="http://rcn-ee.online/supercon/"
 
 dl_web () {
-	wget -c --directory-prefix=./${pre}/ ${web_mirror}${pre}/${file}
+	wget --progress=bar:force -c --directory-prefix=./${pre}/ ${web_mirror}${pre}/${file}
 }
 
 dl_local () {
 	if [ ! -f ./${pre}/${file} ] ; then
-		wget --timeout=2 --tries=2 -c --directory-prefix=./${pre}/ ${local_mirror}${pre}/${file} || dl_web
+		wget --progress=bar:force --timeout=2 --tries=2 -c --directory-prefix=./${pre}/ ${local_mirror}${pre}/${file} || dl_web
 	fi
 }
 


### PR DESCRIPTION
@RobertCNelson , I've followed the process and found that I could further automate it using Vagrant. Vagrant will handle creating the virtual machine, installing the toolchain, getting the build dependencies, and getting the source code. The user can then build inside the VM from their host's command prompt, which makes it appear more seamless. I tested this on Windows and it works.

Except for file sharing between host and guest (due to various OS interaction issues), this should make the workshop setup easier.

I still have to set up the microSD card adapter, which I can do once I know the VID PID of the adapter.

Please let me know what you think!